### PR TITLE
RCE-Fixed

### DIFF
--- a/tools/render-ansible-tasks.py
+++ b/tools/render-ansible-tasks.py
@@ -58,7 +58,7 @@ def main():
     output = opts.output
     # We open the resource registry once
     resource_registry = "./overcloud-resource-registry-puppet.yaml"
-    resource_reg = yaml.load(open(os.path.join(resource_registry), 'r'))
+    resource_reg = yaml.safe_load(open(os.path.join(resource_registry), 'r'))
 
     if (opts.all):
         # This means we will parse all the services defined
@@ -73,7 +73,7 @@ def main():
             # The service definition will be the same resource registry
             role_resources = resource_reg
         else:
-            role_resources = yaml.load(open(os.path.join("./roles/", role + ".yaml"), 'r'))
+            role_resources = yaml.safe_load(open(os.path.join("./roles/", role + ".yaml"), 'r'))
 
         for section_task in opts.ansible_tasks:
             if(opts.all):
@@ -102,7 +102,7 @@ def main():
                     if('::' in config_file):
                         print("This is a nested Heat resource")
                     else:
-                        data_source = yaml.load(open("./" + config_file, 'r'))
+                        data_source = yaml.safe_load(open("./" + config_file, 'r'))
                         expression = engine(
                           "$.outputs.role_data.value.get(" + section_task + ").flatten().distinct()"
                         )
@@ -121,7 +121,7 @@ def main():
                         if exc.errno != errno.EEXIST:
                             raise
                 save = open(tasks_output_file, 'w+')
-                yaml.dump(yaml.load(json.dumps(role_ansible_tasks)), save, default_flow_style=False)
+                yaml.dump(yaml.safe_load(json.dumps(role_ansible_tasks)), save, default_flow_style=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
:pencil2: Change Description
:bar_chart: Metadata *

Heat templates for deploying OpenStack. Mirror of code maintained at opendev.org.

Bounty URL: https://www.huntr.dev/bounties/1-other-tripleo-heat-templates
:gear: Description *

This package was vulnerable to YAML deserialization attack caused by unsafe load function yaml.load()


:computer: Technical Description *

Fixed by avoiding unsafe loader.

:bug: Proof of Concept (PoC) *

Create the following PoC file:
exploit.py

```
import os
os.system('git clone https://github.com/openstack/tripleo-heat-templates.git')
os.chdir('tripleo-heat-templates/tools/')
exp = """!!python/object/new:type
  args: ["z", !!python/tuple [], {"extend": !!python/name:exec }]
  listitems: "__import__('os').system('xcalc')"
"""
open('overcloud-resource-registry-puppet.yaml','w+').write(exp)
os.system('''python render-ansible-tasks.py --output ./ --ansible-tasks ./ --roles-list sdfsd''')
```

Execute the following commands in another terminal:

```
python3 exploit.py
```

    Check the Output:

xcalc will pop up.

:fire: Proof of Fix (PoF) *

After fix it will not popup a calc.

:+1: User Acceptance Testing (UAT)

After fix functionality is unaffected.
